### PR TITLE
swap calibration_n and sampling n, adjust batch size for training

### DIFF
--- a/configs/inference/rl_calibration_math.toml
+++ b/configs/inference/rl_calibration_math.toml
@@ -1,6 +1,6 @@
 model_name = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 dataset = "justus27/math-hendrycks-genesys-format"
-batch_size = 14
+batch_size = 32
 dp = 6
 rollout_path = "outputs"
 output_path = "data_rollout"


### PR DESCRIPTION
seems appropriate since the task we train on is the calibration task, so it should use the default parameters and the passrate-checking step should use the custom parameters

also adjust sample count to make sure batch is full at each step (this number is quite big though so not great for debugging)